### PR TITLE
Setup basic authZ for frontend

### DIFF
--- a/Client/src/routes/+layout.svelte
+++ b/Client/src/routes/+layout.svelte
@@ -11,7 +11,7 @@
 	</main>
 
 	<footer>
-		<p>visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to learn SvelteKit</p>
+		<p>Thanks for taking interest in my interactive resume</p>
 	</footer>
 </div>
 

--- a/Client/src/routes/about/+page.svelte
+++ b/Client/src/routes/about/+page.svelte
@@ -1,26 +1,35 @@
+<script>
+	import { hasOneOf } from '../../services/authentication';
+	import { UserRole } from '../../../../Server/models';
+</script>
+
 <svelte:head>
 	<title>About</title>
 	<meta name="description" content="About this app" />
 </svelte:head>
 
-<div class="text-column">
-	<h1>About this app</h1>
+{#if hasOneOf([UserRole.Test])}
+	<div class="text-column">
+		<h1>About this app</h1>
 
-	<p>
-		This is a <a href="https://kit.svelte.dev">SvelteKit</a> app. You can make your own by typing the
-		following into your command line and following the prompts:
-	</p>
+		<p>
+			This is a <a href="https://kit.svelte.dev">SvelteKit</a> app. You can make your own by typing the
+			following into your command line and following the prompts:
+		</p>
 
-	<pre>npm create svelte@latest</pre>
+		<pre>npm create svelte@latest</pre>
 
-	<p>
-		The page you're looking at is purely static HTML, with no client-side interactivity needed.
-		Because of that, we don't need to load any JavaScript. Try viewing the page's source, or opening
-		the devtools network panel and reloading.
-	</p>
+		<p>
+			The page you're looking at is purely static HTML, with no client-side interactivity needed.
+			Because of that, we don't need to load any JavaScript. Try viewing the page's source, or
+			opening the devtools network panel and reloading.
+		</p>
 
-	<p>
-		The <a href="/sverdle">Sverdle</a> page illustrates SvelteKit's data loading and form handling. Try
-		using it with JavaScript disabled!
-	</p>
-</div>
+		<p>
+			The <a href="/sverdle">Sverdle</a> page illustrates SvelteKit's data loading and form handling.
+			Try using it with JavaScript disabled!
+		</p>
+	</div>
+{:else}
+	<div class="text-column">Unauthorized</div>
+{/if}

--- a/Client/src/services/authentication.ts
+++ b/Client/src/services/authentication.ts
@@ -1,0 +1,45 @@
+import { writable } from "svelte/store";
+import { UserRole } from "../../../Server/models";
+
+
+type AuthTracker = {
+  authenticated: boolean,
+  roles?: UserRole[],
+  expires?: Date
+}
+
+let initialAuth: AuthTracker = {
+  authenticated: false,
+  roles: [],
+  expires: undefined
+}
+
+// Check if we're running on client-side
+if (typeof window !== "undefined") {
+  try {
+    initialAuth = JSON.parse(localStorage.getItem("auth") ?? "") as AuthTracker;
+  } catch (e) {
+    console.error("Could not parse roles from localStorage", e);
+  }
+}
+
+export const authTracker = writable(initialAuth);
+
+// Make sure to update localStorage only in client-side
+if (typeof window !== "undefined") {
+  authTracker.subscribe(val => {
+    try {
+      localStorage.setItem("auth", JSON.stringify(val));
+    } catch (e) {
+      console.error("Could not store auth to localStorage", e);
+    }
+  });
+}
+
+export function hasOneOf(roles: UserRole[]): boolean {
+  let hasRole = false;
+  authTracker.subscribe(($authTracker) => {
+    hasRole = $authTracker.roles?.some(role => roles.includes(role)) || false;
+  })();
+  return hasRole;
+}

--- a/Client/tests/test.ts
+++ b/Client/tests/test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test('about page has expected h1', async ({ page }) => {
+test('about page has expected h1 when unathorized', async ({ page }) => {
 	await page.goto('/about');
-	await expect(page.getByRole('heading', { name: 'About this app' })).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Unauthorized' })).toBeVisible();
 });

--- a/Server/models/index.ts
+++ b/Server/models/index.ts
@@ -1,2 +1,2 @@
 export { Experience } from './experience'
-export { Role } from './roles'
+export { Role, UserRole } from './roles'

--- a/Server/models/roles.ts
+++ b/Server/models/roles.ts
@@ -1,11 +1,23 @@
+export enum UserRole {
+  Admin = "admin",
+  Recruiter = "recruiter",
+  Test = "test"
+}
+
 import * as mongoose from 'mongoose';
 
-const roleSchema = new mongoose.Schema(
-  {
-    email: { type: String, required: true },
-    roles: { type: [String], default: [] }
+const roleSchema = new mongoose.Schema({
+  email: { type: String, required: true },
+  roles: {
+    type: [String],
+    enum: Object.values(UserRole),
+    default: []
   }
-);
+});
 
-export type Role = mongoose.InferSchemaType<typeof roleSchema>;
-export const Role = mongoose.model('Role', roleSchema);
+export type Role = mongoose.Document & {
+  email: string;
+  roles: UserRole[];
+};
+
+export const Role = mongoose.model<Role>('Role', roleSchema);

--- a/Server/plugins/auth.ts
+++ b/Server/plugins/auth.ts
@@ -1,6 +1,6 @@
 import { Elysia, t } from 'elysia'
 import { jwt } from '@elysiajs/jwt'
-import { Role } from '../models';
+import { Role, UserRole } from '../models';
 import cors from '@elysiajs/cors';
 
 export const googleAuth = new Elysia()
@@ -45,7 +45,7 @@ export const googleAuth = new Elysia()
 
       const email = googleData.email;
 
-      const roles = (await Role.findOne({ email }))?.roles ?? ['recruiter'];
+      const roles = (await Role.findOne({ email }))?.roles ?? [UserRole.Recruiter];
 
       const jwtToken = await jwt.sign({ "roles": `${JSON.stringify(roles)}` })
 
@@ -59,7 +59,8 @@ export const googleAuth = new Elysia()
 
       auth.expires = date;
 
-      return `ok`
+      set.headers['expires'] = date.toISOString();
+      return roles;
     },
     {
       cookie: t.Cookie({

--- a/Server/plugins/experiences.ts
+++ b/Server/plugins/experiences.ts
@@ -1,21 +1,13 @@
 import cors from '@elysiajs/cors';
-import { Experience } from '../models';
+import { Experience, UserRole } from '../models';
 import Elysia, { t } from 'elysia';
+import cookie from '@elysiajs/cookie';
+import jwt from '@elysiajs/jwt';
+import { validateUserRole } from './validateUserRole';
 
 export const experiences = new Elysia()
-  .use(cors({
-    credentials: true,
-    origin: (request: Request): boolean => {
-      const origin = request.headers.get('origin');
-      if (!origin) {
-        return false;
-      }
-      const allowedOrigins = JSON.parse(Bun.env.ALLOWED_DOMAINS || '[]') as string[];
-      return allowedOrigins.includes(origin);
-    },
-  }))
+  .use(validateUserRole([UserRole.Test]))
   .get('/experiences',
     async ({ cookie: { auth } }) => {
-      console.log(auth.value);
       return await Experience.find();
     })

--- a/Server/plugins/validateUserRole.ts
+++ b/Server/plugins/validateUserRole.ts
@@ -1,0 +1,38 @@
+import cors from "@elysiajs/cors";
+import jwt from "@elysiajs/jwt";
+import Elysia from "elysia";
+import { UserRole } from "../models";
+
+type validationType = 'OR' | 'AND';
+
+
+export const validateUserRole = (roles: UserRole[], type: validationType = 'OR') => new Elysia()
+  .use(cors({
+    origin: (request: Request): boolean => {
+      const origin = request.headers.get('origin');
+      if (!origin) {
+        return false;
+      }
+      const allowedOrigins = JSON.parse(Bun.env.ALLOWED_DOMAINS || '[]') as string[];
+      return allowedOrigins.includes(origin);
+    }
+  }))
+  .use(jwt({
+    name: 'jwt',
+    secret: Bun.env.JWT_SECRET!,
+    exp: '7d'
+  }))
+  .onBeforeHandle(async ({ cookie: { auth }, jwt, set }) => {
+    const user = await jwt.verify(auth.value);
+
+    if (!user) {
+      set.status = 401
+      return 'Unauthorized'
+    }
+
+    const jwtRoles = JSON.parse(user['roles'] ?? "[]") as UserRole[];
+
+    if (jwtRoles.some(role => roles.includes(role))) {
+      return;
+    }
+  });


### PR DESCRIPTION
Create some layout frontend auth
- Chose not to get and persist jwt on the front end, just a tracker.
The Drawback is that front end backend (Sveltekit) can be accessed through local storage manipulation.
I don't think it is an issue for now, as only api really needs authZ