### PR TITLE
Redesign UI: cards, filters, drawer sidebar & dark mode toggle

### DIFF
--- a/client/src/lib/components/Experience.svelte
+++ b/client/src/lib/components/Experience.svelte
@@ -4,11 +4,24 @@
 	import Project from './Project.svelte';
 	import ExperienceModal from './modals/ExperienceModal.svelte';
 	import { Dialog, Portal } from '@skeletonlabs/skeleton-svelte';
-	import { PencilSquare } from 'svelte-heros-v2';
+	import { PencilSquare, Briefcase, User, AcademicCap, Heart } from 'svelte-heros-v2';
+	import { ExperienceType } from 'portfolio-common';
 	import { marked } from 'marked';
 
-	let { experience, canEdit = false }: { experience: ExperienceModel; canEdit?: boolean } = $props();
+	const typeIcons: Record<ExperienceType, typeof Briefcase> = {
+		[ExperienceType.Professional]: Briefcase,
+		[ExperienceType.Personal]: User,
+		[ExperienceType.Educational]: AcademicCap,
+		[ExperienceType.Leisure]: Heart
+	};
 
+	let { experience, canEdit = false, activeFilters = { softSkills: new Set<string>(), hardSkills: new Set<string>() } }: {
+		experience: ExperienceModel;
+		canEdit?: boolean;
+		activeFilters?: { softSkills: Set<string>; hardSkills: Set<string> };
+	} = $props();
+
+	let DefaultIcon = $derived(typeIcons[experience.type]);
 	let showEditModal = $state(false);
 
 	const onEditResponse = (response: ExperienceModel | undefined) => {
@@ -19,25 +32,35 @@
 	};
 </script>
 
-<div class="preset-outlined-surface-200-800 relative block rounded-lg p-2 m-1 text-left hover:brightness-110 transition-all">
+<div class="card preset-outlined-surface-200-800 relative rounded-lg p-4 text-left shadow-md">
 	{#if canEdit}
 		<button
-			class="absolute top-2 right-2 bg-blue-500 text-white p-1 rounded"
+			class="btn-icon btn-icon-sm preset-tonal-primary absolute top-3 right-3"
 			onclick={() => showEditModal = true}
 		>
-			<PencilSquare />
+			<PencilSquare size="16" />
+			<span class="sr-only">Edit</span>
 		</button>
 	{/if}
-	<article>
-		<h2 id={`${experience._id}`}>{experience.title}</h2>
-		<div class="summary">
+	<article class="space-y-3">
+		<div class="flex items-center gap-2">
+			{#if experience.icon}
+				<img src={experience.icon} alt={experience.type} class="size-6" />
+			{:else}
+				<DefaultIcon size="24" />
+			{/if}
+			<h2 class="text-xl font-bold">{experience.title}</h2>
+		</div>
+		<div class="summary text-sm opacity-90">
 			{@html marked(experience.summary)}
 		</div>
-		<ul>
-			{#each experience.projects as project}
-				<Project {project} experienceId={`${experience._id}`} />
-			{/each}
-		</ul>
+		{#if experience.projects.length > 0}
+			<div class="space-y-3 pt-2">
+				{#each experience.projects as project}
+					<Project {project} experienceId={`${experience._id}`} {activeFilters} />
+				{/each}
+			</div>
+		{/if}
 	</article>
 </div>
 
@@ -63,6 +86,9 @@
 <style>
 	.summary :global(ul) {
 		list-style: disc;
-		padding-left: 20px;
+		padding-left: 1.25rem;
+	}
+	.summary :global(p) {
+		margin-bottom: 0.25rem;
 	}
 </style>

--- a/client/src/lib/components/Header.svelte
+++ b/client/src/lib/components/Header.svelte
@@ -20,7 +20,7 @@
 <AppBar>
 	<AppBar.Toolbar class="grid-cols-[auto_1fr_auto]">
 		<AppBar.Lead><Logo height="50" width="50" /></AppBar.Lead>
-		<AppBar.Headline>
+		<AppBar.Headline class="text-center">
 			{#if headerTitle}
 				<h1 class="text-3xl font-bold">
 					<span
@@ -54,7 +54,7 @@
 			{#if !ready}
 				...
 			{:else if ($authenticationStore.expires ?? 0) * 1000 > Date.now()}
-				<button type="button" onclick={logout} aria-label="Logout">Logout</button>
+				<button type="button" class="btn btn-sm preset-tonal" onclick={logout} aria-label="Logout">Logout</button>
 			{:else}
 				<Login />
 			{/if}

--- a/client/src/lib/components/LeftBar.svelte
+++ b/client/src/lib/components/LeftBar.svelte
@@ -1,21 +1,24 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { Navigation, Switch } from '@skeletonlabs/skeleton-svelte';
+	import { Navigation } from '@skeletonlabs/skeleton-svelte';
 	import type { Domain, Experience } from 'portfolio-api/models/database';
-	import { AcademicCap, ComputerDesktop, WrenchScrewdriver } from 'svelte-heros-v2';
+	import { AcademicCap, ComputerDesktop, WrenchScrewdriver, ChevronRight, Sun, Moon } from 'svelte-heros-v2';
 	import { authenticationStore } from '$services/stores';
 	import { browser } from '$app/environment';
 
 	let { domain }: { domain: Omit<Domain, 'experiences'> & { experiences: Experience[] } } = $props();
 
 	let mounted = $state(false);
-	$effect(() => { mounted = true; });
+	$effect(() => {
+		mounted = true;
+	});
 
 	let isAdmin = $derived(
-		mounted && browser &&
-		$authenticationStore.user?._id != null &&
-		domain?.admin != null &&
-		$authenticationStore.user._id == domain.admin
+		mounted &&
+			browser &&
+			$authenticationStore.user?._id != null &&
+			domain?.admin != null &&
+			$authenticationStore.user._id == domain.admin
 	);
 
 	const pathStartsWith = (path: string, pagePathName: string) => pagePathName.startsWith(path);
@@ -49,7 +52,8 @@
 		if (!browser) return true;
 		const stored = localStorage.getItem(DARK_MODE_KEY);
 		if (stored !== null) return stored === 'true';
-		if (domain?.defaultDarkMode !== undefined && domain.defaultDarkMode !== null) return domain.defaultDarkMode;
+		if (domain?.defaultDarkMode !== undefined && domain.defaultDarkMode !== null)
+			return domain.defaultDarkMode;
 		return window.matchMedia('(prefers-color-scheme: dark)').matches;
 	}
 
@@ -62,36 +66,245 @@
 		localStorage.setItem(DARK_MODE_KEY, String(darkMode));
 	});
 
-	function toggleDarkMode(details: { checked: boolean }) {
-		darkMode = details.checked;
+	function toggleDarkMode() {
+		darkMode = !darkMode;
+	}
+
+	let isOpen = $state(true);
+	let pinned = $state(false);
+
+	// Auto-collapse after 3 seconds on mount
+	$effect(() => {
+		if (!browser) return;
+		const timer = setTimeout(() => {
+			if (!pinned) {
+				isOpen = false;
+			}
+		}, 3000);
+		return () => clearTimeout(timer);
+	});
+
+	function onMouseEnter() {
+		if (!pinned) {
+			isOpen = true;
+		}
+	}
+
+	function onMouseLeave() {
+		if (!pinned) {
+			isOpen = false;
+		}
+	}
+
+	function handleToggle() {
+		if (pinned) {
+			pinned = false;
+			isOpen = false;
+		} else {
+			pinned = true;
+			isOpen = true;
+		}
 	}
 </script>
 
-<Navigation layout="rail">
-	<Navigation.Content>
-		{#each menuItems as item}
-			{#if !item.display || item.display()}
-				{@const isActive = (item.selected ?? pathAreEquals)(item.path, $page.url.pathname)}
-				<Navigation.TriggerAnchor
-					href={`/${domain.name}${item.path}`}
-					aria-current={isActive ? 'page' : undefined}
-					data-active={isActive || undefined}
-				>
-					{#if item.icon}
-						{@const Icon = item.icon}
-						<Icon />
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	class="drawer-wrapper"
+	class:drawer-open={isOpen}
+	onmouseenter={onMouseEnter}
+	onmouseleave={onMouseLeave}
+>
+	<div class="drawer-content">
+		<Navigation layout="rail">
+			<Navigation.Content>
+				{#each menuItems as item}
+					{#if !item.display || item.display()}
+						{@const isActive = (item.selected ?? pathAreEquals)(item.path, $page.url.pathname)}
+						<Navigation.TriggerAnchor
+							href={`/${domain.name}${item.path}`}
+							aria-current={isActive ? 'page' : undefined}
+							data-active={isActive || undefined}
+						>
+							{#if item.icon}
+								{@const Icon = item.icon}
+								<Icon />
+							{/if}
+							<span>{item.label}</span>
+						</Navigation.TriggerAnchor>
 					{/if}
-					<span>{item.label}</span>
-				</Navigation.TriggerAnchor>
-			{/if}
-		{/each}
-	</Navigation.Content>
-	<Navigation.Footer class="mt-auto">
-		<Switch checked={darkMode} onCheckedChange={toggleDarkMode}>
-			<Switch.Control>
-				<Switch.Thumb />
-			</Switch.Control>
-			<Switch.HiddenInput />
-		</Switch>
-	</Navigation.Footer>
-</Navigation>
+				{/each}
+			</Navigation.Content>
+			<Navigation.Footer class="mt-auto flex justify-center">
+				<button
+					class="theme-toggle"
+					class:is-dark={darkMode}
+					onclick={toggleDarkMode}
+					aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+				>
+					<span class="toggle-track">
+						<span class="toggle-icon sun-icon">
+							<Sun size="14" />
+						</span>
+						<span class="toggle-icon moon-icon">
+							<Moon size="14" />
+						</span>
+						<span class="toggle-thumb"></span>
+					</span>
+				</button>
+			</Navigation.Footer>
+		</Navigation>
+	</div>
+
+	<button
+		class="drawer-handle"
+		onclick={handleToggle}
+		aria-label={isOpen ? 'Close sidebar' : 'Open sidebar'}
+	>
+		<span class="handle-icon" class:rotated={isOpen}>
+			<ChevronRight size="14" />
+		</span>
+	</button>
+</div>
+
+<style>
+	.drawer-wrapper {
+		position: absolute;
+		top: 0;
+		left: 0;
+		height: 100%;
+		z-index: 20;
+		display: flex;
+		/* Peek: slide left so only the handle is visible */
+		transform: translateX(calc(-100% + var(--handle-w)));
+		transition: transform 0.3s ease;
+		--handle-w: 20px;
+	}
+
+	.drawer-wrapper.drawer-open {
+		transform: translateX(0);
+	}
+
+	.drawer-content {
+		height: 100%;
+		flex-shrink: 0;
+	}
+
+	.drawer-handle {
+		flex-shrink: 0;
+		width: var(--handle-w);
+		height: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		cursor: pointer;
+		border: none;
+		padding: 0;
+		background: transparent;
+	}
+
+	.handle-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 16px;
+		height: 40px;
+		border-radius: 0 6px 6px 0;
+		background: var(--color-surface-200);
+		opacity: 0.6;
+		transition:
+			opacity 0.2s,
+			transform 0.3s ease;
+	}
+
+	:global(.dark) .handle-icon {
+		background: var(--color-surface-800);
+	}
+
+	.drawer-handle:hover .handle-icon {
+		opacity: 1;
+	}
+
+	.handle-icon.rotated {
+		transform: rotate(180deg);
+	}
+
+	/* Sun/Moon theme toggle */
+	.theme-toggle {
+		border: none;
+		background: none;
+		padding: 0;
+		cursor: pointer;
+		display: flex;
+		justify-content: center;
+	}
+
+	.toggle-track {
+		position: relative;
+		width: 48px;
+		height: 26px;
+		border-radius: 13px;
+		background: linear-gradient(135deg, #89CFF0, #FFD700);
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0 5px;
+		transition: background 0.4s ease;
+	}
+
+	.is-dark .toggle-track {
+		background: linear-gradient(135deg, #1a1a3e, #2d2d6b);
+	}
+
+	.toggle-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 1;
+		transition: opacity 0.3s ease;
+	}
+
+	.sun-icon {
+		color: #f59e0b;
+	}
+
+	.is-dark .sun-icon {
+		opacity: 0.3;
+	}
+
+	.moon-icon {
+		color: #fbbf24;
+	}
+
+	:not(.is-dark) > .toggle-track > .moon-icon {
+		opacity: 0.3;
+	}
+
+	.toggle-thumb {
+		position: absolute;
+		top: 3px;
+		left: 3px;
+		width: 20px;
+		height: 20px;
+		border-radius: 50%;
+		background: white;
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+		transition: transform 0.3s ease;
+	}
+
+	.is-dark .toggle-thumb {
+		transform: translateX(22px);
+		background: #e2e8f0;
+	}
+
+	/* Mobile: bigger tap target */
+	@media (max-width: 767px) {
+		.drawer-wrapper {
+			--handle-w: 28px;
+		}
+
+		.handle-icon {
+			width: 22px;
+			height: 48px;
+		}
+	}
+</style>

--- a/client/src/lib/components/Login.svelte
+++ b/client/src/lib/components/Login.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { login } from '$services/authentication';
+	import { browser } from '$app/environment';
 
 	let googleReady = false;
 	let mounted = false;
@@ -23,10 +24,13 @@
 		}
 	};
 
+	const isDark = () => {
+		if (!browser) return true;
+		return document.documentElement.classList.contains('dark');
+	};
+
 	const displaySignInButton = () => {
-		if (!googleReady) {
-			return;
-		}
+		if (!googleReady) return;
 
 		const signIn = async (credentialResponse: google.accounts.id.CredentialResponse) => {
 			return login(credentialResponse.credential);
@@ -43,15 +47,23 @@
 		google.accounts.id.renderButton(
 			document.getElementById('googleButton')!,
 			{
-				theme: 'filled_black',
+				theme: isDark() ? 'filled_black' : 'outline',
 				size: 'medium',
 				type: 'icon',
-				text: 'continue_with',
-				shape: 'pill'
-			} // customization attributes
+				shape: 'circle'
+			}
 		);
-		google.accounts.id.prompt(); // also display the One Tap dialog
+		google.accounts.id.prompt();
 	};
 </script>
 
-<div id="googleButton"></div>
+<div id="googleButton" class="google-btn"></div>
+
+<style>
+	.google-btn :global(div),
+	.google-btn :global(iframe) {
+		background: transparent !important;
+		border-radius: 50%;
+		color-scheme: auto;
+	}
+</style>

--- a/client/src/lib/components/Project.svelte
+++ b/client/src/lib/components/Project.svelte
@@ -2,26 +2,50 @@
 	import type { Project, Skill as SkillModel } from 'portfolio-api/models/database';
 	import Skill from './Skill.svelte';
 	import { marked } from 'marked';
-	let { project, experienceId }: { project: Project; experienceId: String } = $props();
+	let { project, experienceId, activeFilters = { softSkills: new Set<string>(), hardSkills: new Set<string>() } }: {
+		project: Project;
+		experienceId: String;
+		activeFilters?: { softSkills: Set<string>; hardSkills: Set<string> };
+	} = $props();
 
 	const castSkill = (skill: unknown) => {
 		return skill as SkillModel;
 	};
+
+	const formatDate = (date: unknown) => {
+		if (!date) return '';
+		const d = date instanceof Date ? date : new Date(String(date));
+		return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+	};
 </script>
 
-<div class="block card preset-tonal-secondary p-2 m-1 hover:brightness-110 transition-all">
+<div class="card preset-tonal-surface p-3 space-y-2 shadow-sm">
 	<article>
-		<h3 id={`${project.name}_${experienceId}`}>{project.name}</h3>
-		<h4 data-toc-ignore>{project.start} - {project.end}</h4>
-		<p>{@html marked(project.summary ?? '')}</p>
-
-		<div>
-			{#each project.hardSkills as hardSkill}
-				<Skill skill={castSkill(hardSkill.skill)} level={hardSkill.level || -1} />
-			{/each}
-			{#each project.softSkills as softSkill}
-				<Skill skill={castSkill(softSkill.skill)} level={softSkill.level || -1} />
-			{/each}
+		<h3 class="font-semibold" id={`${project.name}_${experienceId}`}>{project.name}</h3>
+		<p class="text-xs opacity-70">{formatDate(project.start)} — {formatDate(project.end)}</p>
+		<div class="summary text-sm mt-1">
+			{@html marked(project.summary ?? '')}
 		</div>
+
+		{#if project.hardSkills.length > 0 || project.softSkills.length > 0}
+			<div class="flex flex-wrap gap-1 pt-2">
+				{#each project.hardSkills as hardSkill}
+					<Skill skill={castSkill(hardSkill.skill)} level={hardSkill.level || -1} highlighted={activeFilters.hardSkills.has(castSkill(hardSkill.skill).displayName)} />
+				{/each}
+				{#each project.softSkills as softSkill}
+					<Skill skill={castSkill(softSkill.skill)} level={softSkill.level || -1} highlighted={activeFilters.softSkills.has(castSkill(softSkill.skill).displayName)} />
+				{/each}
+			</div>
+		{/if}
 	</article>
 </div>
+
+<style>
+	.summary :global(ul) {
+		list-style: disc;
+		padding-left: 1.25rem;
+	}
+	.summary :global(p) {
+		margin-bottom: 0.25rem;
+	}
+</style>

--- a/client/src/lib/components/Skill.svelte
+++ b/client/src/lib/components/Skill.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import type { Skill } from 'portfolio-api/models/database';
-	let { skill, level }: { skill: Skill; level: number } = $props();
+	let { skill, level, highlighted = false }: { skill: Skill; level: number; highlighted?: boolean } = $props();
 </script>
 
-<span class="chip preset-filled-primary-500">
+<span class="chip transition-all {highlighted ? 'preset-filled-primary-700-300 ring-2 ring-primary-700-300 scale-105' : 'preset-tonal-primary'}">
 	{skill.displayName}
 </span>

--- a/client/src/lib/components/modals/ExperienceModal.svelte
+++ b/client/src/lib/components/modals/ExperienceModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { portfolioApi } from '$services';
-	import { Plus } from 'svelte-heros-v2';
+	import { Plus, XMark } from 'svelte-heros-v2';
 	import { TagsInput, SegmentedControl } from '@skeletonlabs/skeleton-svelte';
 	import { ExperienceType } from 'portfolio-common';
 	import { newExperienceDataStore, type FormData } from '$lib/stores/newExperienceStore';
@@ -27,12 +27,38 @@
 
 	let isNewExperience = $derived(!existingExperience);
 
+	let iconError = $state('');
+
+	const handleIconUpload = (event: Event) => {
+		const input = event.target as HTMLInputElement;
+		const file = input.files?.[0];
+		iconError = '';
+		if (!file) return;
+
+		if (file.size > 16 * 1024) {
+			iconError = 'Icon must be 16KB or smaller';
+			input.value = '';
+			return;
+		}
+
+		const reader = new FileReader();
+		reader.onload = () => {
+			formData.icon = reader.result as string;
+		};
+		reader.readAsDataURL(file);
+	};
+
+	const removeIcon = () => {
+		formData.icon = undefined;
+	};
+
 	function getInitialFormData(): FormData {
 		if (existingExperience) {
 			const data: FormData = {
 				title: existingExperience.title,
 				type: existingExperience.type,
 				summary: existingExperience.summary,
+				icon: existingExperience.icon,
 				company: existingExperience.company as unknown as FormData['company'],
 				projects: existingExperience.projects.map((project) => {
 					const toDateStr = (v: unknown) =>
@@ -137,6 +163,29 @@
 			{/each}
 			<SegmentedControl.Indicator />
 		</SegmentedControl>
+
+		<label class="block">
+			<span>Icon</span>
+			<div class="flex items-center gap-3">
+				{#if formData.icon}
+					<img src={formData.icon} alt="Icon preview" class="size-8" />
+					<button type="button" class="btn btn-sm preset-tonal" onclick={removeIcon}>
+						<XMark size="16" />
+						<span>Remove</span>
+					</button>
+				{:else}
+					<input
+						type="file"
+						accept=".ico,image/x-icon"
+						class="text-sm"
+						onchange={handleIconUpload}
+					/>
+				{/if}
+			</div>
+			{#if iconError}
+				<span class="text-xs text-error-500">{iconError}</span>
+			{/if}
+		</label>
 
 		<textarea
 			class="w-full rounded border border-surface-300-700 bg-transparent p-2"

--- a/client/src/lib/stores/newExperienceStore.ts
+++ b/client/src/lib/stores/newExperienceStore.ts
@@ -23,6 +23,7 @@ const defaultExperience: FormData = {
   summary: '',
   company: { name: '' },
   type: ExperienceType.Professional,
+  icon: undefined,
   projects: [],
 }
 

--- a/client/src/routes/[domain]/+layout.svelte
+++ b/client/src/routes/[domain]/+layout.svelte
@@ -20,11 +20,11 @@
 		<header>
 			<Header headerTitle={data.domain.headerTitle} headerSubtitle={data.domain.headerSubtitle} />
 		</header>
-		<div class="flex flex-1 overflow-hidden">
-			<aside class="w-auto h-full">
+		<div class="relative flex-1 overflow-hidden">
+			<aside>
 				<LeftBar domain={data.domain} />
 			</aside>
-			<main class="flex-1 overflow-auto scroll-smooth" id="page">
+			<main class="h-full overflow-auto scroll-smooth" id="page">
 				{@render children()}
 			</main>
 		</div>

--- a/client/src/routes/[domain]/admin/+page.svelte
+++ b/client/src/routes/[domain]/admin/+page.svelte
@@ -84,7 +84,7 @@
 			{#each SKELETON_THEMES as t (t)}
 				<button
 					type="button"
-					class="btn {theme === t ? 'preset-filled-primary-500' : 'preset-outlined'} text-xs"
+					class="btn {theme === t ? 'preset-filled-primary-700-300' : 'preset-outlined'} text-xs"
 					onclick={() => previewTheme(t)}
 				>
 					{t}
@@ -133,7 +133,7 @@
 	</section>
 
 	<div class="flex items-center gap-4">
-		<button type="button" class="btn preset-filled-primary-500" disabled={saving} onclick={save}>
+		<button type="button" class="btn preset-filled-primary-700-300" disabled={saving} onclick={save}>
 			{saving ? 'Saving...' : 'Save Settings'}
 		</button>
 		{#if message}

--- a/client/src/routes/[domain]/experiences/+page.svelte
+++ b/client/src/routes/[domain]/experiences/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Experience as ExperienceModel } from 'portfolio-api/models/database';
 	import type { PageData } from './$types';
-	import { PlusCircle } from 'svelte-heros-v2';
+	import { Plus } from 'svelte-heros-v2';
 	import { Dialog, Portal } from '@skeletonlabs/skeleton-svelte';
 	import Experience from '$components/Experience.svelte';
 	import ExperienceModal from '$components/modals/ExperienceModal.svelte';
@@ -13,13 +13,16 @@
 	let { data }: { data: PageData } = $props();
 
 	let mounted = $state(false);
-	$effect(() => { mounted = true; });
+	$effect(() => {
+		mounted = true;
+	});
 
 	let isAdmin = $derived(
-		mounted && browser &&
-		$authenticationStore.user?._id != null &&
-		data?.domain?.admin != null &&
-		$authenticationStore.user._id == data.domain.admin
+		mounted &&
+			browser &&
+			$authenticationStore.user?._id != null &&
+			data?.domain?.admin != null &&
+			$authenticationStore.user._id == data.domain.admin
 	);
 	let showAddModal = $state(false);
 	let filters: { softSkills: Set<string>; hardSkills: Set<string> } = $state({
@@ -54,37 +57,43 @@
 		content="All of my professional experiences, as well as my personal and educational projects and courses."
 	/>
 </svelte:head>
-<div class="relative flex items-start gap-10 p-4">
-	<div class="mx-auto text-center flex-1">
+<div class="relative flex items-start p-4 md:p-6">
+	<div class="mx-auto w-full max-w-4xl space-y-4">
 		{#if !experiences}
-			Loading
+			<p class="text-center text-surface-600-400">Loading...</p>
 		{/if}
 		{#if experiences}
-			<Filters bind:filters {experiences} />
+			<Filters bind:filters allExperiences={data.domain!.experiences} />
 
 			{#if !showAddModal && isAdmin}
-				<button class="sticky bg-blue-500 text-white p-1 rounded" onclick={() => showAddModal = true}>
-					<PlusCircle />
+				<button
+					class="btn-icon btn-icon-sm preset-filled-primary-700-300 fixed bottom-2 right-6 z-10 shadow-lg"
+					onclick={() => (showAddModal = true)}
+				>
+					<Plus size="18" class="stroke-[3]" />
+					<span class="sr-only">Add Experience</span>
 				</button>
 			{/if}
 			{#each experiences as experience}
-				<Experience {experience} canEdit={isAdmin} />
+				<Experience {experience} canEdit={isAdmin} activeFilters={filters} />
 			{/each}
 		{/if}
 	</div>
 </div>
 
-<Dialog open={showAddModal} onOpenChange={(details) => showAddModal = details.open}>
+<Dialog open={showAddModal} onOpenChange={(details) => (showAddModal = details.open)}>
 	<Portal>
 		<Dialog.Backdrop class="fixed inset-0 z-50 bg-surface-50-950/50" />
 		<Dialog.Positioner class="fixed inset-0 z-50 flex justify-center items-center p-4">
-			<Dialog.Content class="card bg-surface-100-900 w-full max-w-xl shadow-xl max-h-[calc(100vh-2rem)] overflow-y-auto">
+			<Dialog.Content
+				class="card bg-surface-100-900 w-full max-w-xl shadow-xl max-h-[calc(100vh-2rem)] overflow-y-auto"
+			>
 				{#if showAddModal}
 					<ExperienceModal
 						title="Experience"
 						body="Add a new experience to your resume."
 						onResponse={onAddResponse}
-						onClose={() => showAddModal = false}
+						onClose={() => (showAddModal = false)}
 					/>
 				{/if}
 			</Dialog.Content>

--- a/client/src/routes/[domain]/experiences/Filters.svelte
+++ b/client/src/routes/[domain]/experiences/Filters.svelte
@@ -2,14 +2,14 @@
 	import { Check } from 'svelte-heros-v2';
 	import type { Experience as ExperienceModel, Skill } from 'portfolio-api/models/database';
 
-	let { experiences, filters = $bindable({ softSkills: new Set<string>(), hardSkills: new Set<string>() }) }: {
-		experiences: ExperienceModel[];
+	let { allExperiences, filters = $bindable({ softSkills: new Set<string>(), hardSkills: new Set<string>() }) }: {
+		allExperiences: ExperienceModel[];
 		filters?: { softSkills: Set<string>; hardSkills: Set<string> };
 	} = $props();
 
 	let softSkills = $derived(
 		Array.from(
-			experiences
+			allExperiences
 				.flatMap((e) => e.projects.flatMap((p) => p.softSkills))
 				.reduce((map, skill) => map.set((skill.skill as Skill).displayName, skill.skill), new Map())
 				.values()
@@ -18,7 +18,7 @@
 
 	let hardSkills = $derived(
 		Array.from(
-			experiences
+			allExperiences
 				.flatMap((e) => e.projects.flatMap((p) => p.hardSkills))
 				.reduce((map, skill) => map.set((skill.skill as Skill).displayName, skill.skill), new Map())
 				.values()
@@ -26,15 +26,15 @@
 	);
 </script>
 
-<div class="w-full grid grid-cols-1 md:grid-cols-2 p-2">
-	<div class="card m-1 p-1 preset-tonal-surface">
+<div class="w-full grid grid-cols-1 md:grid-cols-2 gap-3">
+	<div class="card p-3 preset-tonal-surface flex flex-wrap gap-1 shadow-sm">
 		{#each softSkills as softSkill, index}
 			{@const selected = filters.softSkills.has(softSkill.displayName)}
 			<button
 				type="button"
 				role="checkbox"
 				aria-checked={selected}
-				class="chip {selected ? 'preset-outlined-primary-500' : 'preset-tonal-surface'}"
+				class="chip {selected ? 'preset-outlined-primary-700-300' : 'preset-tonal-surface'}"
 				onclick={() => {
 					if (!selected) {
 						filters = {
@@ -53,19 +53,19 @@
 					}
 				}}
 			>
-				{#if selected}<Check size="12px" />{/if}
+				<span class="inline-block w-3">{#if selected}<Check size="12px" />{/if}</span>
 				<span class="capitalize">{softSkill.displayName}</span>
 			</button>
 		{/each}
 	</div>
-	<div class="card m-1 p-1 preset-tonal-surface">
+	<div class="card p-3 preset-tonal-surface flex flex-wrap gap-1 shadow-sm">
 		{#each hardSkills as hardSkill, index}
 			{@const selected = filters.hardSkills.has(hardSkill.displayName)}
 			<button
 				type="button"
 				role="checkbox"
 				aria-checked={selected}
-				class="chip {selected ? 'preset-outlined-primary-500' : 'preset-tonal-surface'}"
+				class="chip {selected ? 'preset-outlined-primary-700-300' : 'preset-tonal-surface'}"
 				onclick={() => {
 					if (!selected) {
 						filters = {
@@ -84,7 +84,7 @@
 					}
 				}}
 			>
-				{#if selected}<Check size="12px" />{/if}
+				<span class="inline-block w-3">{#if selected}<Check size="12px" />{/if}</span>
 				<span class="capitalize">{hardSkill.displayName}</span>
 			</button>
 		{/each}

--- a/server/models/database/experience.ts
+++ b/server/models/database/experience.ts
@@ -13,6 +13,7 @@ export interface Experience extends Document {
   summary: string;
   summaryType: string;
   title: string;
+  icon?: string;
   projects: Project[]
 }
 
@@ -25,6 +26,7 @@ const experienceSchema = new Schema<Experience>({
   company: { type: Types.ObjectId, ref: 'Company' },
   summary: String,
   title: { type: String, required: true },
+  icon: String,
   projects: [projectSchema]
 });
 
@@ -36,6 +38,7 @@ experienceSchema.statics.fromRequest = async function (request: ExperienceReques
     summary: request.summary,
     type: request.type,
     company: request.company,
+    icon: request.icon,
   });
 
   for (const project of request.projects) {

--- a/server/models/elysia/experienceRequest.models.ts
+++ b/server/models/elysia/experienceRequest.models.ts
@@ -32,5 +32,6 @@ export const experienceRequest = t.Object({
   title: t.String(),
   company: t.Optional(companyModel),
   summary: t.String(),
+  icon: t.Optional(t.String()),
   projects: t.Array(projectModel),
 })

--- a/server/plugins/experiences.ts
+++ b/server/plugins/experiences.ts
@@ -67,6 +67,7 @@ export const experiences = new Elysia()
       summary: body.summary,
       type: body.type,
       company: body.company,
+      icon: body.icon,
       projects,
     });
 


### PR DESCRIPTION
## Summary
- **Experience cards**: Restyle with proper spacing, type icons, shadows, and icon-only edit/add buttons (sr-only text for accessibility)
- **Skill filters**: Improved chip layout with selection indicators and active skill highlighting on experience cards
- **Drawer sidebar**: Auto-hides after 3s, peeks on hover, pin/unpin via chevron handle, mobile-friendly tap targets
- **Dark mode toggle**: Custom sun/moon toggle with gradient track replacing the Skeleton Switch
- **Experience icons**: Add icon upload support (modal, server model, API)
- **Theme consistency**: Replace all `primary-500` presets with `primary-700-300`
- **Add Experience FAB**: Fixed bottom-right floating action button on all screen sizes

## Test plan
- [ ] Verify experience cards render with type icons and proper spacing
- [ ] Check skill highlighting when filters are active
- [ ] Test drawer: auto-collapse after 3s, hover open/close, click pin/unpin
- [ ] Test drawer on mobile: tap chevron to open/close
- [ ] Verify sun/moon dark mode toggle switches themes correctly
- [ ] Confirm FAB add experience button appears for admin users
- [ ] Test icon upload in experience modal (max 16KB .ico files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Redesign the experiences page layout and navigation sidebar, introducing richer card, filter, and theme controls.

New Features:
- Add a collapsible, hover-peek sidebar with a chevron handle and a custom sun/moon dark mode toggle.
- Introduce experience type icons and optional uploaded icons on experience cards and modal forms.
- Highlight hard and soft skills on projects based on active filter selections and display a floating add-experience action button for admins.

Enhancements:
- Restyle experience and project cards, filters, and header for improved spacing, typography, and visual hierarchy.
- Adjust Google login button styling and theme handling to better match light/dark modes.
- Align theme usage by replacing primary-500 presets with primary-700-300 variants in skills and admin settings.