### PR TITLE
Restructure admin panel into tabbed layout

### DIFF
--- a/client/src/lib/components/admin/AppointmentsTab.svelte
+++ b/client/src/lib/components/admin/AppointmentsTab.svelte
@@ -1,0 +1,9 @@
+<div class="space-y-8">
+	<section class="card p-6 space-y-4">
+		<h2 class="h3">Appointments</h2>
+		<p class="opacity-75">
+			Manage your available time slots for phone calls and meetings via Google Calendar.
+		</p>
+		<p class="text-sm opacity-50">Coming soon.</p>
+	</section>
+</div>

--- a/client/src/lib/components/admin/CosmeticSettings.svelte
+++ b/client/src/lib/components/admin/CosmeticSettings.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { portfolioApi } from '$services';
+	import { Switch } from '@skeletonlabs/skeleton-svelte';
+	import { browser } from '$app/environment';
+
+	const SKELETON_THEMES = [
+		'catppuccin',
+		'cerberus',
+		'concord',
+		'crimson',
+		'fennec',
+		'hamlindigo',
+		'legacy',
+		'mint',
+		'modern',
+		'mona',
+		'nosh',
+		'nouveau',
+		'pine',
+		'reign',
+		'rocket',
+		'rose',
+		'sahara',
+		'seafoam',
+		'terminus',
+		'vintage',
+		'vox',
+		'wintry'
+	];
+
+	let domain = $derived($page.data.domain);
+
+	let theme = $state($page.data.domain?.theme ?? 'wintry');
+	let headerTitle = $state($page.data.domain?.headerTitle ?? '');
+	let headerSubtitle = $state($page.data.domain?.headerSubtitle ?? '');
+	let defaultDarkMode = $state($page.data.domain?.defaultDarkMode ?? false);
+	let saving = $state(false);
+	let message = $state('');
+
+	function previewTheme(newTheme: string) {
+		theme = newTheme;
+		if (browser) {
+			document.documentElement.dataset.theme = newTheme;
+		}
+	}
+
+	async function save() {
+		saving = true;
+		message = '';
+
+		const { error } = await portfolioApi.domain({ name: domain.name }).put(
+			{
+				theme,
+				headerTitle: headerTitle || undefined,
+				headerSubtitle: headerSubtitle || undefined,
+				defaultDarkMode
+			},
+			{ fetch: { credentials: 'include' } }
+		);
+
+		saving = false;
+
+		if (error) {
+			message = 'Failed to save settings.';
+		} else {
+			message = 'Settings saved!';
+		}
+	}
+</script>
+
+<div class="space-y-8">
+	<section class="card p-6 space-y-4">
+		<h2 class="h3">Theme</h2>
+		<p class="opacity-75">Select a Skeleton theme for your portfolio. Changes preview instantly.</p>
+		<div class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-2">
+			{#each SKELETON_THEMES as t (t)}
+				<button
+					type="button"
+					class="btn {theme === t ? 'preset-filled-primary-700-300' : 'preset-outlined'} text-xs"
+					onclick={() => previewTheme(t)}
+				>
+					{t}
+				</button>
+			{/each}
+		</div>
+	</section>
+
+	<section class="card p-6 space-y-4">
+		<h2 class="h3">Header</h2>
+		<label class="label">
+			<span>Title</span>
+			<input
+				class="input"
+				type="text"
+				placeholder="e.g. John Doe"
+				bind:value={headerTitle}
+			/>
+		</label>
+		<label class="label">
+			<span>Subtitle</span>
+			<input
+				class="input"
+				type="text"
+				placeholder="e.g. Full Stack Developer & Problem Solver"
+				bind:value={headerSubtitle}
+			/>
+		</label>
+	</section>
+
+	<section class="card p-6 space-y-4">
+		<h2 class="h3">Default Dark Mode</h2>
+		<p class="opacity-75">Set the default dark mode preference for first-time visitors.</p>
+		<div class="flex items-center gap-3">
+			<Switch
+				checked={defaultDarkMode}
+				onCheckedChange={(details) => (defaultDarkMode = details.checked)}
+			>
+				<Switch.Control>
+					<Switch.Thumb />
+				</Switch.Control>
+				<Switch.HiddenInput />
+			</Switch>
+			<span>{defaultDarkMode ? 'Dark' : 'Light'}</span>
+		</div>
+	</section>
+
+	<div class="flex items-center gap-4">
+		<button type="button" class="btn preset-filled-primary-700-300" disabled={saving} onclick={save}>
+			{saving ? 'Saving...' : 'Save Settings'}
+		</button>
+		{#if message}
+			<span class="text-sm">{message}</span>
+		{/if}
+	</div>
+</div>

--- a/client/src/lib/components/admin/WorkflowsTab.svelte
+++ b/client/src/lib/components/admin/WorkflowsTab.svelte
@@ -1,0 +1,9 @@
+<div class="space-y-8">
+	<section class="card p-6 space-y-4">
+		<h2 class="h3">Workflows</h2>
+		<p class="opacity-75">
+			Configure the steps visitors must complete to access your contacts or agenda.
+		</p>
+		<p class="text-sm opacity-50">Coming soon.</p>
+	</section>
+</div>

--- a/client/src/routes/[domain]/admin/+page.svelte
+++ b/client/src/routes/[domain]/admin/+page.svelte
@@ -1,72 +1,8 @@
 <script lang="ts">
-	import { page } from '$app/stores';
-	import { portfolioApi } from '$services';
-	import { Switch } from '@skeletonlabs/skeleton-svelte';
-	import { browser } from '$app/environment';
-
-	const SKELETON_THEMES = [
-		'catppuccin',
-		'cerberus',
-		'concord',
-		'crimson',
-		'fennec',
-		'hamlindigo',
-		'legacy',
-		'mint',
-		'modern',
-		'mona',
-		'nosh',
-		'nouveau',
-		'pine',
-		'reign',
-		'rocket',
-		'rose',
-		'sahara',
-		'seafoam',
-		'terminus',
-		'vintage',
-		'vox',
-		'wintry'
-	];
-
-	let domain = $derived($page.data.domain);
-
-	let theme = $state($page.data.domain?.theme ?? 'wintry');
-	let headerTitle = $state($page.data.domain?.headerTitle ?? '');
-	let headerSubtitle = $state($page.data.domain?.headerSubtitle ?? '');
-	let defaultDarkMode = $state($page.data.domain?.defaultDarkMode ?? false);
-	let saving = $state(false);
-	let message = $state('');
-
-	function previewTheme(newTheme: string) {
-		theme = newTheme;
-		if (browser) {
-			document.documentElement.dataset.theme = newTheme;
-		}
-	}
-
-	async function save() {
-		saving = true;
-		message = '';
-
-		const { error } = await portfolioApi.domain({ name: domain.name }).put(
-			{
-				theme,
-				headerTitle: headerTitle || undefined,
-				headerSubtitle: headerSubtitle || undefined,
-				defaultDarkMode
-			},
-			{ fetch: { credentials: 'include' } }
-		);
-
-		saving = false;
-
-		if (error) {
-			message = 'Failed to save settings.';
-		} else {
-			message = 'Settings saved!';
-		}
-	}
+	import { Tabs } from '@skeletonlabs/skeleton-svelte';
+	import CosmeticSettings from '$components/admin/CosmeticSettings.svelte';
+	import WorkflowsTab from '$components/admin/WorkflowsTab.svelte';
+	import AppointmentsTab from '$components/admin/AppointmentsTab.svelte';
 </script>
 
 <svelte:head>
@@ -74,70 +10,26 @@
 	<meta name="description" content="Admin settings" />
 </svelte:head>
 
-<div class="p-8 max-w-2xl mx-auto space-y-8">
-	<h1 class="h1">Admin Settings</h1>
-
-	<section class="card p-6 space-y-4">
-		<h2 class="h3">Theme</h2>
-		<p class="opacity-75">Select a Skeleton theme for your portfolio. Changes preview instantly.</p>
-		<div class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-2">
-			{#each SKELETON_THEMES as t (t)}
-				<button
-					type="button"
-					class="btn {theme === t ? 'preset-filled-primary-700-300' : 'preset-outlined'} text-xs"
-					onclick={() => previewTheme(t)}
-				>
-					{t}
-				</button>
-			{/each}
+<div class="max-w-4xl mx-auto">
+	<Tabs defaultValue="appearance">
+		<div class="sticky top-0 z-10 bg-surface-50-950">
+			<Tabs.List>
+				<Tabs.Trigger value="appearance">Appearance</Tabs.Trigger>
+				<Tabs.Trigger value="workflows">Workflows</Tabs.Trigger>
+				<Tabs.Trigger value="appointments">Appointments</Tabs.Trigger>
+				<Tabs.Indicator />
+			</Tabs.List>
 		</div>
-	</section>
-
-	<section class="card p-6 space-y-4">
-		<h2 class="h3">Header</h2>
-		<label class="label">
-			<span>Title</span>
-			<input
-				class="input"
-				type="text"
-				placeholder="e.g. John Doe"
-				bind:value={headerTitle}
-			/>
-		</label>
-		<label class="label">
-			<span>Subtitle</span>
-			<input
-				class="input"
-				type="text"
-				placeholder="e.g. Full Stack Developer & Problem Solver"
-				bind:value={headerSubtitle}
-			/>
-		</label>
-	</section>
-
-	<section class="card p-6 space-y-4">
-		<h2 class="h3">Default Dark Mode</h2>
-		<p class="opacity-75">Set the default dark mode preference for first-time visitors.</p>
-		<div class="flex items-center gap-3">
-			<Switch
-				checked={defaultDarkMode}
-				onCheckedChange={(details) => (defaultDarkMode = details.checked)}
-			>
-				<Switch.Control>
-					<Switch.Thumb />
-				</Switch.Control>
-				<Switch.HiddenInput />
-			</Switch>
-			<span>{defaultDarkMode ? 'Dark' : 'Light'}</span>
+		<div class="p-8">
+			<Tabs.Content value="appearance">
+				<CosmeticSettings />
+			</Tabs.Content>
+			<Tabs.Content value="workflows">
+				<WorkflowsTab />
+			</Tabs.Content>
+			<Tabs.Content value="appointments">
+				<AppointmentsTab />
+			</Tabs.Content>
 		</div>
-	</section>
-
-	<div class="flex items-center gap-4">
-		<button type="button" class="btn preset-filled-primary-700-300" disabled={saving} onclick={save}>
-			{saving ? 'Saving...' : 'Save Settings'}
-		</button>
-		{#if message}
-			<span class="text-sm">{message}</span>
-		{/if}
-	</div>
+	</Tabs>
 </div>


### PR DESCRIPTION
## Summary
- Refactored the admin page into a **tabbed interface** using Skeleton UI `Tabs`
- Extracted existing appearance settings (theme, header, dark mode) into a dedicated `CosmeticSettings.svelte` component
- Added placeholder tabs for **Workflows** (#63) and **Appointments** (#64)
- Tab bar is sticky so it remains visible when scrolling

## Test plan
- [ ] Verify the Appearance tab contains all existing settings (theme selector, header inputs, dark mode toggle, save)
- [ ] Verify theme preview and save still work correctly
- [ ] Verify Workflows and Appointments tabs show placeholder content
- [ ] Verify sticky tab bar stays visible on scroll
- [ ] Verify responsive layout on mobile/tablet/desktop

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restructure the admin settings page into a tabbed interface and extract appearance configuration into dedicated components while adding placeholders for future workflows and appointments management.

New Features:
- Introduce a tabbed admin layout using Skeleton UI Tabs with a sticky tab bar for navigation between sections.
- Add dedicated Workflows and Appointments admin tabs with placeholder content describing upcoming functionality.

Enhancements:
- Extract cosmetic appearance settings (theme, header, dark mode) into a reusable CosmeticSettings component to simplify the admin page layout.