### PR TITLE
Bound HTTP metric cardinality to matched route patterns

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -9,11 +9,13 @@ export const createApp = () =>
   new Elysia()
     .use(instrumentation)
     .derive(() => ({ requestStart: performance.now() }))
-    .onAfterResponse(({ request, requestStart }) => {
+    .onAfterResponse(({ request, requestStart, route }) => {
       const method = request.method
-      const route = new URL(request.url).pathname
       const duration = performance.now() - requestStart
-      const attrs = { method, route }
+      // Matched route pattern only (e.g. /experiences/:id) — raw pathnames are
+      // unbounded (scanner bots) and each unique value is a metric series kept
+      // in memory forever
+      const attrs = { method, route: route || 'unmatched' }
       httpRequestCounter.add(1, attrs)
       httpRequestDuration.record(duration, attrs)
     })


### PR DESCRIPTION
## Problème

Depuis l'ajout d'OpenTelemetry (#61), les métriques HTTP utilisaient le pathname brut de chaque requête comme attribut `route`. Les scanners internet sondent des milliers de chemins uniques (`/.env`, `/wp-admin`, backdoors PHP...), et chaque chemin unique créait une série de métriques **permanente** :

- mémoire du process en croissance continue (pics observés jusqu'à ~8 Go sur Railway) avec redémarrages en dents de scie
- payload OTLP ré-exporté toutes les 60 s de plus en plus gros (egress + active series Grafana Cloud)

Confirmé dans Grafana : des centaines de séries du type `{method=GET, route=/wp-includes/wlwmanifest.xml}`.

## Correctif

`onAfterResponse` utilise maintenant `route` du contexte Elysia — le pattern de route enregistré (ex. `/domain/:domainName`) — au lieu du pathname brut. Les requêtes sans route matchée sont regroupées dans une série unique `unmatched`. La cardinalité est bornée au nombre de routes déclarées.

## Vérification après déploiement

- Mémoire Railway stable en plateau (< ~100 Mo), plus de dents de scie
- `count({__name__=~http_server_request.*})` plat dans Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Limit HTTP metrics cardinality by recording only matched Elysia route patterns instead of raw request pathnames, with unmatched requests grouped under a single placeholder value.

Enhancements:
- Use the framework-provided matched route pattern for HTTP metric attributes to bound series cardinality and reduce memory usage.
- Group all requests without a matched route into a single `unmatched` metric series to avoid unbounded label growth.