### PR TITLE
Return 404 for unexpected routes and proper error statuses

### DIFF
--- a/client/src/app.d.ts
+++ b/client/src/app.d.ts
@@ -2,7 +2,11 @@
 // for information about these interfaces
 declare global {
 	namespace App {
-		// interface Error {}
+		interface Error {
+			message: string;
+			// Set on 404s for unclaimed domains so the error page can offer the claim flow
+			domainName?: string;
+		}
 		// interface Locals {}
 		// interface PageData {}
 		// interface Platform {}

--- a/client/src/routes/+error.svelte
+++ b/client/src/routes/+error.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import '../app.css';
+	import ClaimDomain from '$components/ClaimDomain.svelte';
+	import { page } from '$app/stores';
+</script>
+
+{#if $page.status === 404 && $page.error?.domainName}
+	<ClaimDomain domainName={$page.error.domainName} />
+{:else}
+	<div class="h-full flex flex-col items-center justify-center gap-4 p-8">
+		<h1 class="text-4xl font-bold">{$page.status}</h1>
+		<p class="text-lg text-surface-600-400">{$page.error?.message ?? 'Something went wrong'}</p>
+	</div>
+{/if}

--- a/client/src/routes/[domain]/+layout.server.ts
+++ b/client/src/routes/[domain]/+layout.server.ts
@@ -1,16 +1,14 @@
+import { error } from '@sveltejs/kit';
 import { portfolioApi } from '$services/index';
 import type { Domain, Experience } from 'portfolio-api/models/database';
 
 export async function load({ params }) {
-  let { data, error } = await portfolioApi.domain({ name: params.domain }).get({
+  const { data, error: apiError } = await portfolioApi.domain({ name: params.domain }).get({
     fetch: { credentials: 'include' }
   });
 
-  if (error || !data) {
-    return {
-      domain: null,
-      domainName: params.domain
-    };
+  if (apiError || !data) {
+    error(404, { message: 'Domain not found', domainName: params.domain });
   }
 
   return {

--- a/client/src/routes/[domain]/+layout.svelte
+++ b/client/src/routes/[domain]/+layout.svelte
@@ -2,7 +2,6 @@
 	import '../../app.css';
 	import Header from '$components/Header.svelte';
 	import LeftBar from '$components/LeftBar.svelte';
-	import ClaimDomain from '$components/ClaimDomain.svelte';
 	import type { LayoutData } from './$types';
 	import type { Snippet } from 'svelte';
 	import { browser } from '$app/environment';
@@ -10,25 +9,21 @@
 	let { data, children }: { data: LayoutData; children: Snippet } = $props();
 
 	$effect(() => {
-		if (!browser || !data.domain) return;
+		if (!browser) return;
 		document.documentElement.dataset.theme = data.domain.theme ?? 'wintry';
 	});
 </script>
 
-{#if data.domain}
-	<div class="h-full flex flex-col">
-		<header>
-			<Header headerTitle={data.domain.headerTitle} headerSubtitle={data.domain.headerSubtitle} />
-		</header>
-		<div class="relative flex-1 overflow-hidden">
-			<aside>
-				<LeftBar domain={data.domain} />
-			</aside>
-			<main class="h-full overflow-auto scroll-smooth" id="page">
-				{@render children()}
-			</main>
-		</div>
+<div class="h-full flex flex-col">
+	<header>
+		<Header headerTitle={data.domain.headerTitle} headerSubtitle={data.domain.headerSubtitle} />
+	</header>
+	<div class="relative flex-1 overflow-hidden">
+		<aside>
+			<LeftBar domain={data.domain} />
+		</aside>
+		<main class="h-full overflow-auto scroll-smooth" id="page">
+			{@render children()}
+		</main>
 	</div>
-{:else}
-	<ClaimDomain domainName={data.domainName} />
-{/if}
+</div>

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -1,40 +1,55 @@
+// `status` is picked up by Elysia to set the HTTP status of the error response
 export class DomainDoesNotExistError extends Error {
+  status = 404
+  constructor(public message: string) {
+    super(message)
+  }
+}
+
+export class DomainAlreadyExistsError extends Error {
+  status = 409
   constructor(public message: string) {
     super(message)
   }
 }
 
 export class MissingAuthCookieError extends Error {
+  status = 401
   constructor(public message: string) {
     super(message)
   }
 }
 
 export class CouldntVerifyJwtError extends Error {
+  status = 401
   constructor(public message: string) {
     super(message)
   }
 }
 
 export class SubMissingError extends Error {
+  status = 401
   constructor(public message: string) {
     super(message)
   }
 }
 
 export class CannotSaveExperienceError extends Error {
+  status = 500
   constructor(public message: string) {
     super(message)
   }
 }
 
 export class AuthExpiredError extends Error {
+  status = 401
   constructor(public message: string) {
     super(message)
   }
 }
 
 export class UserAlreadyOwnsDomainError extends Error {
+  status = 409
   constructor(public message: string) {
     super(message)
   }
@@ -42,6 +57,7 @@ export class UserAlreadyOwnsDomainError extends Error {
 
 export const errors = {
   DomainDoesNotExistError,
+  DomainAlreadyExistsError,
   MissingAuthCookieError,
   CouldntVerifyJwtError,
   SubMissingError,

--- a/server/plugins/domain.ts
+++ b/server/plugins/domain.ts
@@ -1,6 +1,6 @@
 import Elysia, { t } from 'elysia';
 import { Experience, Domain } from '../models/database';
-import { DomainDoesNotExistError, UserAlreadyOwnsDomainError } from '../errors';
+import { DomainDoesNotExistError, DomainAlreadyExistsError, UserAlreadyOwnsDomainError } from '../errors';
 import { corsConf } from './corsConf';
 import { userLogged } from './userLogged';
 
@@ -56,7 +56,7 @@ const domainClaim = new Elysia()
   .use(userLogged)
   .post('/domain/claim', async ({ body: { name }, userId }) => {
     const existing = await Domain.findOne({ name });
-    if (existing) throw new DomainDoesNotExistError('Domain already exists');
+    if (existing) throw new DomainAlreadyExistsError('Domain already exists');
 
     const ownedDomain = await Domain.findOne({ admin: userId });
     if (ownedDomain) throw new UserAlreadyOwnsDomainError('You already own a domain');

--- a/server/tests/domain.test.ts
+++ b/server/tests/domain.test.ts
@@ -76,12 +76,12 @@ describe('GET /domain/:name', () => {
     expect(response.experiences[0].projects[0].hardSkills[0].skill.displayName).toBe('TypeScript');
   });
 
-  it('should return error for non-existent domain', async () => {
+  it('should return 404 for non-existent domain', async () => {
     Domain.findOne = mock(() => Promise.resolve(null)) as any;
 
     const result = await makeRequest(app, '/domain/nonexistent');
 
-    expect(result.status).not.toBe(200);
+    expect(result.status).toBe(404);
   });
 
   it('should return domain with empty experiences', async () => {
@@ -103,6 +103,14 @@ describe('GET /domain/:name', () => {
   });
 });
 
+describe('unmatched routes', () => {
+  it('should return 404 for routes that do not exist', async () => {
+    const result = await makeRequest(app, '/wp-admin/setup.php');
+
+    expect(result.status).toBe(404);
+  });
+});
+
 describe('PUT /domain/:name', () => {
   beforeEach(() => {
     User.findOneAndUpdate = mock(() => Promise.resolve(testUser)) as any;
@@ -112,7 +120,7 @@ describe('PUT /domain/:name', () => {
   it('should reject requests without auth', async () => {
     const result = await putJson(app, `/domain/${TEST_DOMAIN_NAME}`, { theme: 'crimson' });
 
-    expect(result.status).not.toBe(200);
+    expect(result.status).toBe(401);
   });
 
   it('should update domain settings when user is admin', async () => {
@@ -186,7 +194,7 @@ describe('PUT /domain/:name', () => {
     expect(result.status).not.toBe(200);
   });
 
-  it('should return error for non-existent domain', async () => {
+  it('should return 404 for non-existent domain', async () => {
     const cookie = await loginAndGetCookie(app);
 
     Domain.findOne = mock(() => Promise.resolve(null)) as any;
@@ -198,7 +206,7 @@ describe('PUT /domain/:name', () => {
       cookie
     );
 
-    expect(result.status).not.toBe(200);
+    expect(result.status).toBe(404);
   });
 
   it('should allow partial updates', async () => {


### PR DESCRIPTION
## Problème

Suite du diagnostic mémoire/trafic (#68) : les scanners qui sondent le site ne recevaient pas des 404 partout.

Vérifié sur les services déployés :

| Requête | Avant | Après |
|---|---|---|
| API route inconnue | 404 | 404 (inchangé, test ajouté) |
| API `/domain/<inexistant>` | **500** | 404 |
| Client `/admin.php` (1 segment, matche `[domain]`) | 302 → **200** | 302 → 404 |
| Client chemin multi-segments | 404 | 404 (inchangé) |

## Changements

**Serveur** : les classes d'erreur custom portent maintenant un status HTTP (`DomainDoesNotExistError` 404, erreurs d'auth 401, conflits 409) — Elysia l'utilise automatiquement, notre `onError` ne l'écrase pas. Le claim d'un domaine déjà pris lançait `DomainDoesNotExistError('Domain already exists')` ; remplacé par un `DomainAlreadyExistsError` (409) sémantiquement correct.

**Client** : un domaine inconnu répond désormais **404** via `error(404, { domainName })` dans le layout load. La nouvelle page `+error.svelte` racine rend toujours le composant `ClaimDomain` dans ce cas — le flow « claim this domain » est préservé à l'identique (le `goto(..., { invalidateAll: true })` après claim efface l'état d'erreur). Les autres erreurs ont une page 404/500 simple.

**Tests** : assertions renforcées (`toBe(404)` / `toBe(401)` au lieu de `not.toBe(200)`) + test des routes non matchées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align client and server handling of unknown domains and routes to return appropriate HTTP error statuses and preserve the domain claim flow.

Bug Fixes:
- Return 404 instead of 500 for non-existent domains in the API.
- Return 401 for unauthenticated domain update requests instead of leaving the status unspecified.
- Return 404 for unmatched server routes and unknown single-segment client routes like /admin.php.

Enhancements:
- Attach HTTP status codes to custom server error classes so Elysia can map them to correct responses.
- Introduce a dedicated DomainAlreadyExistsError to represent domain claim conflicts with HTTP 409.
- Surface unknown domains on the client as 404 errors while still allowing users to claim unowned domains via the global error page.

Tests:
- Strengthen API tests with explicit assertions on 404 and 401 statuses and add coverage for unmatched routes.